### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 - Python-Code zum Einlesen der Sensordaten, Steuerung der Pumpe und dem Senden der vom Frontend benötigten Daten an Pubnub 
 - HTML5/JS-Code zur Echtzeit-Darstellung der Daten   
 Der Sensor DHT11 misst sowohl die Temperatur als auch die Luftfeuchtigkeit. Damit der Raspberry Pi den Sensor nutzen kann, wird zu beginn die Bibliothek Adafruit_DHT importiert.  
-Der Output des Feuchtigkeits-Sensors ist entweder 0V (trocken) oder 1V (feucht). Daher wird der Sensor als Button initialisiert. Die Pumpe wird als LED initialisiert, da sie ein binäres Signal erhält.
+Der Output des Feuchtigkeits-Sensors ist entweder 0V (trocken) oder 3,3V (feucht). Daher wird der Sensor als Button initialisiert. Die Pumpe wird als LED initialisiert, da sie ein binäres Signal erhält.
 Je nach erforderlicher Darstellung der Daten im UI, müssen die Sensor-Daten unterschiedlich an das UI übergeben werden. Falls die Luftfeuchtigkeit und die Temperatur im selben Diagramm dargestellt werden sollen, müssen diese zuerst in ein Dictionary geschrieben werden.             
 Zur Echtzeit-Darstellung der Daten wird Pubnub (Data streaming network infrastructure as a service IaaS) verwendet. Der Service benötigt zur Benutzung und der Verbindung zum Front-End einen Subscribe- und einen Publish-Key.
 


### PR DESCRIPTION
Der RasPi kann nur 3,3V an den GPIO Pins ausgeben. Er kann die Ports nur zwischen GND und 3,3V switchen, aber nicht zwischen z.B. 1V und 2V.